### PR TITLE
Support for webpack 3

### DIFF
--- a/src/webpack_sha_hash.js
+++ b/src/webpack_sha_hash.js
@@ -65,10 +65,8 @@ class WebpackSHAHash {
      */
     apply(compiler) {
         compiler.plugin("compilation", (compilation) => {
-          compilation.plugin("chunk-hash", (chunk, chunkHash) => {
-                const chunkModules = chunk.mapModules ? chunk.mapModules(function (c) {
-                  return c;
-                }) : chunk.modules;
+            compilation.plugin("chunk-hash", (chunk, chunkHash) => {
+                const chunkModules = chunk.mapModules ? chunk.mapModules((c) => c) : chunk.modules;
                 const source = chunkModules.sort(this.compareModules).map(this.getModuleSource).reduce(this.concatenateSource, ""); // we provide an initialValue in case there is an empty module source. Ref: http://es5.github.io/#x15.4.4.21
                 const calculatedChunkHash = this.generateHash(source);
 

--- a/src/webpack_sha_hash.js
+++ b/src/webpack_sha_hash.js
@@ -65,8 +65,10 @@ class WebpackSHAHash {
      */
     apply(compiler) {
         compiler.plugin("compilation", (compilation) => {
-            compilation.plugin("chunk-hash", (chunk, chunkHash) => {
-                const chunkModules = chunk.mapModules ? chunk.mapModules(function(c) {return c;}) : chunk.modules;
+          compilation.plugin("chunk-hash", (chunk, chunkHash) => {
+                const chunkModules = chunk.mapModules ? chunk.mapModules(function (c) {
+                  return c;
+                }) : chunk.modules;
                 const source = chunkModules.sort(this.compareModules).map(this.getModuleSource).reduce(this.concatenateSource, ""); // we provide an initialValue in case there is an empty module source. Ref: http://es5.github.io/#x15.4.4.21
                 const calculatedChunkHash = this.generateHash(source);
 

--- a/src/webpack_sha_hash.js
+++ b/src/webpack_sha_hash.js
@@ -66,7 +66,7 @@ class WebpackSHAHash {
     apply(compiler) {
         compiler.plugin("compilation", (compilation) => {
             compilation.plugin("chunk-hash", (chunk, chunkHash) => {
-                const chunkModules = chunk.mapModules ? chunk.mapModules(function (c) { return c; }) : chunk.modules;
+                const chunkModules = chunk.mapModules ? chunk.mapModules(function(c) {return c;}) : chunk.modules;
                 const source = chunkModules.sort(this.compareModules).map(this.getModuleSource).reduce(this.concatenateSource, ""); // we provide an initialValue in case there is an empty module source. Ref: http://es5.github.io/#x15.4.4.21
                 const calculatedChunkHash = this.generateHash(source);
 

--- a/src/webpack_sha_hash.js
+++ b/src/webpack_sha_hash.js
@@ -66,7 +66,8 @@ class WebpackSHAHash {
     apply(compiler) {
         compiler.plugin("compilation", (compilation) => {
             compilation.plugin("chunk-hash", (chunk, chunkHash) => {
-                const source = chunk.modules.sort(this.compareModules).map(this.getModuleSource).reduce(this.concatenateSource, ""); // we provide an initialValue in case there is an empty module source. Ref: http://es5.github.io/#x15.4.4.21
+                const chunkModules = chunk.mapModules ? chunk.mapModules(function (c) { return c; }) : chunk.modules;
+                const source = chunkModules.sort(this.compareModules).map(this.getModuleSource).reduce(this.concatenateSource, ""); // we provide an initialValue in case there is an empty module source. Ref: http://es5.github.io/#x15.4.4.21
                 const calculatedChunkHash = this.generateHash(source);
 
                 chunkHash.digest = () => {


### PR DESCRIPTION
As `Chunk.modules` is deprecated in webpack 3, webpack will throw out warning such as:

```
DeprecationWarning: Chunk.modules is deprecated. Use Chunk.getNumberOfModules/mapModules/forEachModule/containsModule instead.`
```

This PR is aimed to fix the deprecation warning generated by webpack. It also supports webpack 2.

Thanks!